### PR TITLE
Fixed : issue 94

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -22,6 +22,7 @@ const team = [
       width: 580,
       height: 580,
     },
+    linkedin: "https://www.linkedin.com/in/amitesh1208/"
   },
   {
     name: "Bharti Kumari",
@@ -31,8 +32,10 @@ const team = [
       width: 580,
       height: 580,
     },
+    linkedin: "https://www.linkedin.com/in/bhartik021/"
   },
 ];
+
 ---
 
 <Layout title="About">
@@ -57,28 +60,31 @@ const team = [
     </div>
     <div class="grid md:grid-cols-3 gap-10 mx-auto max-w-4xl mt-12">
       {
-        team.map((item) => (
-          <div class="group">
-            <div class="w-full aspect-square">
-              <Picture
-                {...item.avatar}
-                format="avif"
-                alt="Team"
-                widths={[200, 400]}
-                aspectRatio="1:1"
-                sizes="(max-width: 800px) 100vw, 400px"
-                class="w-full h-full object-cover rounded transition  group-hover:-translate-y-1 group-hover:shadow-xl"
-                format="avif"
-              />
-            </div>
+  team.map((item) => (
+    <div class="group">
+      <div class="w-full aspect-square">
+        <a href={item.linkedin} target="_blank" rel="noopener noreferrer">
+          <Picture
+            {...item.avatar}
+            format="avif"
+            alt="Team"
+            widths={[200, 400]}
+            aspectRatio="1:1"
+            sizes="(max-width: 800px) 100vw, 400px"
+            class="w-full h-full object-cover rounded transition group-hover:-translate-y-1 group-hover:shadow-xl"
+            format="avif"
+          />
+        </a>
+      </div>
 
-            <div class="mt-4 text-center">
-              <h2 class="text-lg text-gray-800"> {item.name}</h2>
-              <h3 class="text-sm text-slate-500"> {item.title}</h3>
-            </div>
-          </div>
-        ))
-      }
+      <div class="mt-4 text-center">
+        <h2 class="text-lg text-gray-800"> {item.name}</h2>
+        <h3 class="text-sm text-slate-500"> {item.title}</h3>
+      </div>
+    </div>
+  ))
+}
+
     </div>
   </Container>
 </Layout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,6 +4,7 @@ import Container from "@components/container.astro";
 import Sectionhead from "@components/sectionhead.astro";
 import { Picture } from "@astrojs/image/components";
 
+
 const TeamImg1 =
   "https://cdn.bio.link/uploads/profile_pictures/2021-12-17/rIgWZLgFZMi84ZKzAZ2Rw3K2PbIJ5PJk.png";
 const TeamImg2 =
@@ -22,7 +23,8 @@ const team = [
       width: 580,
       height: 580,
     },
-    linkedin: "https://www.linkedin.com/in/amitesh1208/"
+      linkedin: "https://www.linkedin.com/in/amitesh1208/",
+    github: "https://github.com/Astrodevil"
   },
   {
     name: "Bharti Kumari",
@@ -32,7 +34,8 @@ const team = [
       width: 580,
       height: 580,
     },
-    linkedin: "https://www.linkedin.com/in/bhartik021/"
+     linkedin: "https://www.linkedin.com/in/bhartik021/",
+    github: "https://github.com/bhartik021"
   },
 ];
 
@@ -80,13 +83,31 @@ const team = [
       <div class="mt-4 text-center">
         <h2 class="text-lg text-gray-800"> {item.name}</h2>
         <h3 class="text-sm text-slate-500"> {item.title}</h3>
+                      
+                      <div class="flex justify-center mt-2">
+
+                   <a href={item.github} target="_blank" rel="noopener noreferrer">
+                  <img
+                    src="https://upload.wikimedia.org/wikipedia/commons/c/c2/GitHub_Invertocat_Logo.svg"
+                    alt="GitHub"
+                    class="w-6 h-6 mr-2 social-icon"
+                  />
+                </a>
+                <a href={item.linkedin} target="_blank" rel="noopener noreferrer">
+                  <img
+                    src="https://www.logo.wine/a/logo/LinkedIn/LinkedIn-Icon-Logo.wine.svg"
+                    alt="LinkedIn"
+                    class="w-7 h-7 social-icon"
+                  />
+                </a>
+              </div>
       </div>
     </div>
   ))
 }
 
     </div>
-  </Container>
+  </Container>  
 </Layout>
 
 <style>
@@ -123,6 +144,13 @@ const team = [
 		border-radius: 4px;
 		padding: 0.3em 0.45em;
 	}
+  .social-icon {
+    margin-right: 1rem;
+    transition: transform 0.3s ease;
+  }
+  .social-icon:hover {
+    transform: translateY(-0.5rem);
+  }
 	.instructions strong {
 		color: rgb(var(--accent));
 	}


### PR DESCRIPTION
## Related Issue
In about section when clicking on Project admin and maintainer cards they were not redirecting us to there social media or linkedin handles . 

Closes: #94 


## Description of Changes
I added Linkedin links of both . Now it will redirect us to there Linkedin profiles on clicking . 

## Checklist:

<!--
Mark the checkboxes to indicate completion. Example: 
- [x] My code follows the style guidelines of this project.
-->

- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [x] I have included comments in areas that may be difficult to understand.
- [ ] I have made corresponding updates to the project documentation.
- x] My changes have not introduced any new warnings.


## Screenshots

|      Original       |       Updated        |
| :-----------------: | :------------------: |
| ![Original screenshot]

https://github.com/ZeroOctave/resource-gallery/assets/85991449/ec1cf78c-63cd-4cbd-bc5b-8b934fadf381

 | ![Updated screenshot] 

https://github.com/ZeroOctave/resource-gallery/assets/85991449/631f3f4d-ce7e-4937-b911-a6a23088f174

|


Please provide any necessary screenshots to illustrate the changes made.
