### PR TITLE
fix : Margin-Top of Get Started Button

### DIFF
--- a/src/components/cta.astro
+++ b/src/components/cta.astro
@@ -14,6 +14,6 @@ import Link from "./ui/link.astro";
     <!-- <a href="https://www.producthunt.com/posts/open-source-gallery?utm_source=badge-review&utm_medium=badge&utm_souce=badge-open-source-gallery#discussion-body" target="_blank">
     <img src="https://api.producthunt.com/widgets/embed-image/v1/review.svg?post_id=325005&theme=light" alt="Open Source Gallery - All contents related to Open-Source. | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54"/>
     </a> -->
-    <Link href="./resource" style="inverted" class=" my-2 hover:scale-105 ease-in-out duration-500 bg-gray-100"> Get Started</Link>
+    <Link href="./resource" style="inverted" class=" my-2 mt-8 hover:scale-105 ease-in-out duration-500 bg-gray-100"> Get Started</Link>
   </div>
 </div>


### PR DESCRIPTION
## Related Issue
<!--
Provide information about the issue or bug that is being addressed.
-->

Closes: #253 


## Description of Changes

- **Improved UI of `Get Started Button UI in cta.astro` related content.**
- **Added Modifications done by using `mt-8` with existing Code of `Get Started Button UI`**


## Checklist:

<!--
Mark the checkboxes to indicate completion. Example: 
- [x] My code follows the style guidelines of this project.
-->

- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [ ] I have included comments in areas that may be difficult to understand.
- [ ] I have made corresponding updates to the project documentation.
- [x] My changes have not introduced any new warnings.


## Screenshots

|      Original       |       Updated        |
| :-----------------: | :------------------: |
| 
![resourcegallery-3](https://github.com/ZeroOctave/resource-gallery/assets/84512164/5a47ffd3-a4bc-4b07-8846-142e09f437e4)
| | 
![resourcegallery-4](https://github.com/ZeroOctave/resource-gallery/assets/84512164/a305729c-7dd5-4a03-84de-b1bf10f7b2e7)
|


Please provide any necessary screenshots to illustrate the changes made.
